### PR TITLE
Flexible applist and dependency sorting

### DIFF
--- a/django_seed/management/commands/seed.py
+++ b/django_seed/management/commands/seed.py
@@ -8,11 +8,13 @@ from django_seed.toposort import toposort_flatten
 
 class Command(BaseCommand):
     help = 'Seed your Django database with fake data'
-    requires_system_checks = True
 
     def __init__(self, *args, **kwargs):
+        super(Command, self).__init__(*args, **kwargs)
+
         self.include_models = []
         self.exclude_models = []
+
 
     def add_arguments(self, parser):
         parser.add_argument('args', metavar='app_label[.ModelName]', nargs='*',

--- a/django_seed/management/commands/seed.py
+++ b/django_seed/management/commands/seed.py
@@ -15,16 +15,25 @@ class Command(BaseCommand):
         self.include_models = []
         self.exclude_models = []
 
+        if hasattr(self, 'option_list'):  # Django <=1.7
+            self.add_arguments()
 
-    def add_arguments(self, parser):
-        parser.add_argument('args', metavar='app_label[.ModelName]', nargs='*',
-                            help='Restricts seeding to the specified app_label or app_label.ModelName.')
-        parser.add_argument('-a', '--all', action='store_true', dest='seed_all', default=False,
-                            help="Seed all registered apps.")
-        parser.add_argument('-n', '--number', type=int, default=10, help="Number of each model to seed.")
-        parser.add_argument('-e', '--exclude', dest='exclude', action='append', default=[],
-                            help='An app_label or app_label.ModelName to exclude '
-                                 '(use multiple --exclude to exclude multiple apps/models).')
+    def add_argument(self, parser, *args, **kwargs):
+        if parser:  # Django >= 1.8
+            parser.add_argument(*args, **kwargs)
+        else:  # Django <=1.7
+            self.option_list += ( make_option(*args, **kwargs), )
+
+    def add_arguments(self, parser=None):
+        if parser:
+            self.add_argument(parser, 'applist', metavar='app_label[.ModelName]', nargs='+',
+                              help='Restricts seeding to the specified app_label or app_label.ModelName.')
+        self.add_argument(parser, '-a', '--all', action='store_true', dest='seed_all', default=False,
+                          help="Seed all registered apps.")
+        self.add_argument(parser, '-e', '--exclude', dest='exclude', action='append', default=[],
+                          help='An app_label or app_label.ModelName to exclude '
+                               '(use multiple --exclude to exclude multiple apps/models).')
+        self.add_argument(parser, '-n', '--number', type=int, default=10, help="Number of each model to seed.")
 
     def handle(self, *app_labels, **options):
         number = options.get('number')

--- a/django_seed/management/commands/seed.py
+++ b/django_seed/management/commands/seed.py
@@ -1,40 +1,72 @@
-
-from django.core.management.base import AppCommand
+from django.apps import apps
+from django.core.management.base import BaseCommand
 from django_seed import Seed
 from django_seed.exceptions import SeederCommandError
-from optparse import make_option
-import django
 
 
-class Command(AppCommand):
+class Command(BaseCommand):
     help = 'Seed your Django database with fake data'
 
-    args = "[appname ...]"
+    def add_arguments(self, parser):
+        parser.add_argument('args', metavar='app_label[.ModelName]', nargs='*',
+                            help='Restricts seeding to the specified app_label or app_label.ModelName.')
+        parser.add_argument('-a', '--all', action='store_true', dest='seed_all', default=False,
+                            help="Seed all registered apps.")
+        parser.add_argument('-n', '--number', type=int, default=10, help="Number of each model to seed.")
 
-    option_list = AppCommand.option_list + (
-        make_option('--number', dest='number', default=10,
-                    help='number of each model to seed'),
-    )
+    def add_model(self, model):
+        if model not in self.models:
+            self.models.append(model)
 
-    def handle_app_config(self, app_config, **options):
-        if app_config.models_module is None:
-            raise SeederCommandError('You must provide an app to seed')
+    def handle(self, *app_labels, **options):
+        number = options.get('number')
+        seed_all = options.get('seed_all')
 
-        try:
-            number = int(options['number'])
-        except ValueError:
-            raise SeederCommandError('The value of --number must be an integer')
+        # Collect all models
+        self.models = []
+
+        if len(app_labels) == 0:
+            if seed_all:  # Add all models from all apps
+                for app_config in apps.get_app_configs():
+                    for model in app_config.get_models():
+                        self.add_model(model)
+            else:
+                raise SeederCommandError("You must specify a list of apps or the --all flag")
+        else:
+            for label in app_labels:
+                try:
+                    app_label, model_label = label.split('.')
+                except ValueError:
+                    # This is just an app - no model qualifier
+                    app_label = label
+                    try:
+                        app_config = apps.get_app_config(app_label)
+                    except LookupError:
+                        raise SeederCommandError("Unknown application: %s" % app_label)
+                    for model in app_config.get_models():
+                        self.add_model(model)
+                else:
+                    # app.model specified
+                    try:
+                        app_config = apps.get_app_config(app_label)
+                    except LookupError:
+                        raise SeederCommandError("Unknown application: %s" % app_label)
+                    try:
+                        model = app_config.get_model(model_label)
+                    except LookupError:
+                        raise SeederCommandError("Unknown model: %s.%s" % (app_label, model_label))
+                    self.add_model(model)
 
         seeder = Seed.seeder()
 
         # don't diplay warnings about non-timezone aware datetimes
         import warnings
+
         warnings.showwarning = lambda *x: None
 
-        for model in app_config.get_models():
+        for model in self.models:
             seeder.add_entity(model, number)
             print('Seeding %i %ss' % (number, model.__name__))
 
         pks = seeder.execute()
         print(pks)
-

--- a/django_seed/toposort.py
+++ b/django_seed/toposort.py
@@ -1,0 +1,67 @@
+#######################################################################
+# Implements a topological sort algorithm.
+# https://bitbucket.org/ericvsmith/toposort/src/25b5894c4229cb888f77cf0c077c05e2464446ac/toposort.py
+#
+# Copyright 2014 True Blade Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+########################################################################
+
+from functools import reduce as _reduce
+
+__all__ = ['toposort', 'toposort_flatten']
+
+def toposort(data):
+    """Dependencies are expressed as a dictionary whose keys are items
+and whose values are a set of dependent items. Output is a list of
+sets in topological order. The first set consists of items with no
+dependences, each subsequent set consists of items that depend upon
+items in the preceeding sets.
+"""
+
+    # Special case empty input.
+    if len(data) == 0:
+        return
+
+    # Copy the input so as to leave it unmodified.
+    data = data.copy()
+
+    # Ignore self dependencies.
+    for k, v in data.items():
+        v.discard(k)
+    # Find all items that don't depend on anything.
+    extra_items_in_deps = _reduce(set.union, data.values()) - set(data.keys())
+    # Add empty dependences where needed.
+    data.update({item:set() for item in extra_items_in_deps})
+    while True:
+        ordered = set(item for item, dep in data.items() if len(dep) == 0)
+        if not ordered:
+            break
+        yield ordered
+        data = {item: (dep - ordered)
+                for item, dep in data.items()
+                    if item not in ordered}
+    if len(data) != 0:
+        raise ValueError('Cyclic dependencies exist among these items: {}'.format(', '.join(repr(x) for x in data.items())))
+
+
+def toposort_flatten(data, sort=True):
+    """Returns a single list of dependencies. For any set returned by
+toposort(), those items are sorted and appended to the result (just to
+make the results deterministic)."""
+
+    result = []
+    for d in toposort(data):
+        result.extend((sorted if sort else list)(d))
+    return result


### PR DESCRIPTION
Started some work on allowing more flexibility in defining apps/models to seed (cribbed from Django's dumpdata command) and defining and sorting dependencies among the models.

Needs some more work; specifically on https://github.com/paulshannon/django-seed/blob/flexible_applist/django_seed/management/commands/seed.py#L93-L101

I've run into a couple of problems, not sure if I'm hitting some bugs or if I'm missing something.

This also uses some 1.8 features. Not sure how much of a problem that is.