### PR TITLE
Change IntegerField and PositiveIntegerField to smaller integer provider.

### DIFF
--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -68,8 +68,8 @@ class FieldTypeGuesser(object):
         if isinstance(field, PositiveSmallIntegerField): return lambda x: provider.rand_small_int(pos=True)
         if isinstance(field, SmallIntegerField): return lambda x: provider.rand_small_int()
         if isinstance(field, BigIntegerField): return lambda x: provider.rand_big_int()
-        if isinstance(field, PositiveIntegerField): return lambda x: provider.rand_int(pos=True)
-        if isinstance(field, IntegerField): return lambda x: provider.rand_int()
+        if isinstance(field, PositiveIntegerField): return lambda x: provider.rand_small_int(pos=True)
+        if isinstance(field, IntegerField): return lambda x: provider.rand_small_int()
         if isinstance(field, FloatField): return lambda x: provider.rand_float()
         if isinstance(field, DecimalField): return lambda x: random.random()
 


### PR DESCRIPTION
faker.rand_int(-4294967295, 4294967295) return values outside range supported by all django databases (-2147483648 to 2147483647): https://docs.djangoproject.com/en/1.8/ref/models/fields/#integerfield

Alternatively, you could:

```python
if isinstance(field, IntegerField): return lambda x: random.randint(-2147483648 , 2147483647)
```