### PR TITLE
Do not import django at top level in __init__.py

### DIFF
--- a/django_seed/__init__.py
+++ b/django_seed/__init__.py
@@ -1,5 +1,4 @@
 
-from django.conf import settings
 import random
 
 
@@ -22,6 +21,7 @@ class Seed(object):
 
     @staticmethod
     def codename(locale=None):
+        from django.conf import settings
         locale = locale or getattr(settings,'LANGUAGE_CODE', None)
         codename = locale or 'default'
         return codename


### PR DESCRIPTION
Fixed installing via pip had import django when it might not exist.

This is a quick ugly fix by moving the import into the function which needs it.