### PR TITLE
Fix seed command unrecognized "number" argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+
+env/
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,9 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
-matrix:
-  exclude:
-   - python: "3.5"
-     env: DJANGO=1.7
 install:
   - pip install -q Django==$DJANGO
   - pip install coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - DJANGO=1.7
   - DJANGO=1.8
   - DJANGO=1.9
+  - DJANGO=1.10
 matrix:
   exclude:
    - python: "3.5"

--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -14,7 +14,7 @@ def _timezone_format(value):
     :param value: The datetime value
     :return: A locale aware datetime
     """
-    return timezone.make_aware(value) if getattr(settings, 'USE_TZ', False) else value
+    return timezone.make_aware(value, timezone.get_current_timezone()) if getattr(settings, 'USE_TZ', False) else value
 
 
 class NameGuesser(object):

--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -75,11 +75,9 @@ class FieldTypeGuesser(object):
         faker = self.faker
         provider = self.provider
 
-        if django.VERSION[1] >= 8:
-            if isinstance(field, DurationField):
-                return lambda x: provider.duration()
-            if isinstance(field, UUIDField):
-                return lambda x: provider.uuid()
+
+        if isinstance(field, DurationField): return lambda x: provider.duration()
+        if isinstance(field, UUIDField): return lambda x: provider.uuid()
 
         if isinstance(field, BooleanField): return lambda x: faker.boolean()
         if isinstance(field, NullBooleanField): return lambda x: faker.null_boolean()

--- a/django_seed/management/commands/seed.py
+++ b/django_seed/management/commands/seed.py
@@ -18,6 +18,13 @@ class Command(AppCommand):
                     help='number of each model to seed'),
     ]
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+
+        parser.add_argument('--number', nargs='?', type=int, default=10, const=10,
+                    help='number of each model to seed')
+
+
     def handle_app_config(self, app_config, **options):
         if app_config.models_module is None:
             raise SeederCommandError('You must provide an app to seed')

--- a/django_seed/management/commands/seed.py
+++ b/django_seed/management/commands/seed.py
@@ -45,14 +45,11 @@ class Command(AppCommand):
 
     def dependencies(self, model):
         dependencies = set()
-        if hasattr(model._meta, 'get_fields'):  # Django>=1.8
-            for field in model._meta.get_fields():
-                if field.many_to_one is True and field.concrete and field.blank is False:
-                    dependencies.add(field.related_model)
-        else:  # Django<=1.7
-            for field in model._meta.fields:
-                if isinstance(field, ForeignKey) and field.blank is False:
-                    dependencies.add(field.rel.to)
+
+        for field in model._meta.get_fields():
+            if field.many_to_one is True and field.concrete and field.blank is False:
+                dependencies.add(field.related_model)
+
         return dependencies
 
     def sorted_models(self, app_config):

--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -61,7 +61,7 @@ class ModelSeeder(object):
 
     def execute(self, using, inserted_entities):
         """
-        Execute the stages entities to inserte
+        Execute the stages entities to insert
         :param using:
         :param inserted_entities:
         """

--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -57,9 +57,8 @@ class Action(models.Model):
     )
     name = models.CharField(max_length=4, choices=ACTIONS)
     executed_at = models.DateTimeField()
-    if django.VERSION[1] >= 8:
-        duration = models.DurationField()
-        uuid = models.UUIDField()
+    duration = models.DurationField()
+    uuid = models.UUIDField()
     actor = models.ForeignKey(Player,related_name='actions', null=False)
     target = models.ForeignKey(Player, related_name='enemy_actions+', null=True)
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 django
-fake-factory
+Faker
 coverage
 django-nose
 nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django
-fake-factory
+Faker

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ setup(
     ],
     keywords='faker fixtures data test django seed',
     long_description=open('README.rst', 'r').read(),
-    install_requires=['django>=1.7','fake-factory>=0.5.0'],
-    tests_require=['django>=1.7','fake-factory>=0.5.0', 'coverage', 'django-nose'],
+    install_requires=['django>=1.8','Faker>=0.7.7'],
+    tests_require=['django>=1.8','fake-factory>=0.5.0', 'coverage', 'django-nose'],
     test_suite="runtests.runtests",
     zip_safe=False,
 )


### PR DESCRIPTION
As mentioned by @Brobin on the issue #37 , the problem is that [optparse was discontinued in favor of argparse](https://docs.djangoproject.com/en/1.10/releases/1.8/#extending-management-command-arguments-through-command-option-list) when transitioning from Django 1.7 to 1.8.

The 2 flavors were supported until the version 1.10 was released. Here's the [commit which discontinued the support of optarse](https://github.com/django/django/commit/6a70cb53971a19f2d9e71d5ee24bfb0e844b4d9d#diff-dfc45ab8548a0777543d12d6e77c9173L230).

This is what happening "under the hood" (as far as I can tell):

* Django <= 1.7 - optparse is used, the property `option_list` is consumed

* Django 1.8 - 1.9 - if `option_list` is present optparse is used and the method `add_arguments` is never invoked

* Django 1.10 - the support for `option_list` is removed completely

I'm not completely happy with the change I'm proposing here (having the argument definition duplicated is rather dirty), but it works.

Ideally I'd argue that releasing a new major of the library assuming that Django 1.7 is no longer supported ([as that version of the framework itself is no longer maintained](https://www.djangoproject.com/download/#supported-versions)) would be the best solution to avoid poluting the codebase with [old version-based conditional statements](https://github.com/Brobin/django-seed/blob/master/django_seed/management/commands/seed.py#L45).

If 1.7 support is to be maintained, I'm open to suggestions on a cleaner approach to address the issue. 

PS - Tests are passing under Django 1.10 (that's why I've added them to the CI recipe) but a warning is being emitted.