### PR TITLE
Add "support" for s3direct and hashid fields

### DIFF
--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -68,6 +68,9 @@ class FieldTypeGuesser(object):
         faker = self.faker
         provider = self.provider
 
+        # This check must come first, else isinstance will pass on a subclass
+        # due to the implementation details of HashidField
+        if isinstance(field, HashidField): return lambda x: provider.rand_small_int(pos=True)
 
         if isinstance(field, DurationField): return lambda x: provider.duration()
         if isinstance(field, UUIDField): return lambda x: provider.uuid()
@@ -109,5 +112,4 @@ class FieldTypeGuesser(object):
         if isinstance(field, TimeField): return lambda x: faker.time()
 
         if isinstance(field, S3DirectField): return lambda x: faker.uri()
-        if isinstance(field, HashidField): return lambda x: provider.rand_small_int(pos=True)
         raise AttributeError(field)

--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -1,6 +1,8 @@
 from django.db.models import *
 from django.conf import settings
 from django.utils import timezone
+from s3direct.fields import S3DirectField
+from hashid_field import HashidField
 
 import random
 import re
@@ -105,4 +107,7 @@ class FieldTypeGuesser(object):
             return lambda x: _timezone_format(faker.date_time())
         if isinstance(field, DateField): return lambda x: faker.date()
         if isinstance(field, TimeField): return lambda x: faker.time()
+
+        if isinstance(field, S3DirectField): return lambda x: faker.uri()
+        if isinstance(field, HashidField): return lambda x: provider.rand_small_int(pos=True)
         raise AttributeError(field)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 django
 Faker
+s3direct
+django-hashid-field


### PR DESCRIPTION
This PR allows django-seed to handle s3direct and hashid fields. The way it seeds these fields is not super well thought-out, and was just quickly put together to meet the needs of our particular application. It adds two new dependencies, and does not really add much meaningful functionality, and was kind-of hastily thrown together, but it allowed for seeding data of our application which uses fields from outside of the base django models without falling through to the raising of the AttributeError. 