### PR TITLE
Test fixes; clean ups; localization fix; readme updates; added ability to avoid AttributeError(field)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - pip install -q -e .
   - pip install coveralls
   - pip install alphabet-detector
+  - pip install jsonfield
 script:
   - python runtests.py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - pip install -e git://github.com/django-nose/django-nose.git#egg=django-nose
   - pip install -q -e .
   - pip install coveralls
+  - pip install alphabet-detector
 script:
   - python runtests.py
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -84,12 +84,12 @@ Ex: seeding 5 ``Game`` and 10 ``Player`` objects:
 
     inserted_pks = seeder.execute()
 
-The seeder uses the name and column type to populate the Model with relevant data. If django-seed misinterprets a column name, you can still specify a custom function to be used for populating a particular column, by adding a third argument to the ``add_entity()`` method:
+The seeder uses the name and column type to populate the Model with relevant data. If django-seed misinterprets a column name or column type and *AttributeError(field)* is thrown, you can still specify a custom function to be used for populating a particular column, by adding a third argument to the ``add_entity()`` method:
 
 .. code-block:: python
 
     seeder.add_entity(Player, 10, {
-        'score':    lambda x: random.randint(0,1000),
+        'score':    lambda x: random.randint(0, 1000),
         'nickname': lambda x: seeder.faker.email(),
     })
     seeder.execute()
@@ -103,7 +103,6 @@ Django-seed does not populate auto-incremented primary keys, instead ``seeder.ex
         <class 'faker.django.tests.Player'>: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         <class 'faker.django.tests.Game'>: [1, 2, 3, 4, 5]
     }
-
 
 
 Localization
@@ -131,7 +130,6 @@ or if you have ``django_seed`` in INSTALLED_APPS:
 .. code-block:: bash
 
     $ python manage.py test django_seed
-
 
 -------
 License

--- a/README.rst
+++ b/README.rst
@@ -62,9 +62,8 @@ Ex: Seed 15 of each model for the app ``api``:
 .. code-block:: bash
 
     $ python manage.py seed api --number=15
-    
-That's it! Now you have 15 of each model seeded into your database.
 
+That's it! Now you have 15 of each model seeded into your database.
 
 Using with code
 ----------------
@@ -106,6 +105,17 @@ Django-seed does not populate auto-incremented primary keys, instead ``seeder.ex
     }
 
 
+
+Localization
+------------
+
+``Seed.seeder()`` can take a locale as an argument, to return localized data.
+You can find all possible locales in `faker's documentation`_
+
+In order to apply localization, do the next:
+
+    seeder = Seed.seeder('it_IT')
+
 -----
 Tests
 -----
@@ -121,9 +131,9 @@ or if you have ``django_seed`` in INSTALLED_APPS:
 .. code-block:: bash
 
     $ python manage.py test django_seed
-  
 
--------  
+
+-------
 License
 -------
 
@@ -132,27 +142,28 @@ MIT. See `LICENSE`_ for more details.
 
 .. _faker: https://www.github.com/joke2k/faker/
 .. _django_faker: https://www.github.com/joke2k/django-faker/
+.. _faker's documentation: https://faker.readthedocs.io/en/latest/locales.html
 .. _LICENSE: https://github.com/Brobin/django-seed/blob/master/LICENSE
 
 .. |pypi| image:: https://img.shields.io/pypi/v/django-seed.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/django-seed
+:target: https://pypi.python.org/pypi/django-seed
     :alt: pypi
 
 .. |travis| image:: https://img.shields.io/travis/Brobin/django-seed.svg?style=flat-square
-    :target: http://travis-ci.org/Brobin/django-seed
+:target: http://travis-ci.org/Brobin/django-seed
     :alt: Travis Build
-    
+
 .. |coveralls| image:: https://img.shields.io/coveralls/Brobin/django-seed.svg?style=flat-square
-    :target: https://coveralls.io/r/Brobin/django-seed
+:target: https://coveralls.io/r/Brobin/django-seed
     :alt: coverage
 
 .. |license| image:: https://img.shields.io/github/license/Brobin/django-seed.svg?style=flat-square
-    :target: https://github.com/Brobin/django-seed/blob/master/LICENSE
+:target: https://github.com/Brobin/django-seed/blob/master/LICENSE
     :alt: MIT License
 
 .. |python| image:: https://img.shields.io/pypi/pyversions/django-seed.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/django-seed
+:target: https://pypi.python.org/pypi/django-seed
     :alt: Python 2.7, 3.x
 
 .. |seed-logo| image:: assets/django_seed.png
-    :alt: Django Seed
+:alt: Django Seed

--- a/README.rst
+++ b/README.rst
@@ -144,24 +144,24 @@ MIT. See `LICENSE`_ for more details.
 .. _LICENSE: https://github.com/Brobin/django-seed/blob/master/LICENSE
 
 .. |pypi| image:: https://img.shields.io/pypi/v/django-seed.svg?style=flat-square
-:target: https://pypi.python.org/pypi/django-seed
+    :target: https://pypi.python.org/pypi/django-seed
     :alt: pypi
 
 .. |travis| image:: https://img.shields.io/travis/Brobin/django-seed.svg?style=flat-square
-:target: http://travis-ci.org/Brobin/django-seed
+    :target: http://travis-ci.org/Brobin/django-seed
     :alt: Travis Build
 
 .. |coveralls| image:: https://img.shields.io/coveralls/Brobin/django-seed.svg?style=flat-square
-:target: https://coveralls.io/r/Brobin/django-seed
+    :target: https://coveralls.io/r/Brobin/django-seed
     :alt: coverage
 
 .. |license| image:: https://img.shields.io/github/license/Brobin/django-seed.svg?style=flat-square
-:target: https://github.com/Brobin/django-seed/blob/master/LICENSE
+    :target: https://github.com/Brobin/django-seed/blob/master/LICENSE
     :alt: MIT License
 
 .. |python| image:: https://img.shields.io/pypi/pyversions/django-seed.svg?style=flat-square
-:target: https://pypi.python.org/pypi/django-seed
+    :target: https://pypi.python.org/pypi/django-seed
     :alt: Python 2.7, 3.x
 
 .. |seed-logo| image:: assets/django_seed.png
-:alt: Django Seed
+    :alt: Django Seed

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,8 @@ You can find all possible locales in `faker's documentation`_
 
 In order to apply localization, do the next:
 
+.. code-block:: python
+
     seeder = Seed.seeder('it_IT')
 
 -----

--- a/django_seed/__init__.py
+++ b/django_seed/__init__.py
@@ -31,7 +31,7 @@ class Seed(object):
         code = codename or cls.codename(locale)
         if code not in cls.fakers:
             from faker import Faker
-            cls.fakers[code] = Faker(locale)
+            cls.fakers[code] = Faker(code)
             cls.fakers[code].seed(random.randint(1, 10000))
         return cls.fakers[code]
 

--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -1,5 +1,6 @@
 from django.db.models import *
 from django.conf import settings
+from django.core.validators import validate_comma_separated_integer_list
 from django.utils import timezone
 
 import random
@@ -66,7 +67,6 @@ class FieldTypeGuesser(object):
         faker = self.faker
         provider = self.provider
 
-
         if isinstance(field, DurationField): return lambda x: provider.duration()
         if isinstance(field, UUIDField): return lambda x: provider.uuid()
 
@@ -83,10 +83,11 @@ class FieldTypeGuesser(object):
         if isinstance(field, URLField): return lambda x: faker.uri()
         if isinstance(field, SlugField): return lambda x: faker.uri_page()
         if isinstance(field, IPAddressField) or isinstance(field, GenericIPAddressField):
-            protocol = random.choice(['ipv4','ipv6'])
+            protocol = random.choice(['ipv4', 'ipv6'])
             return lambda x: getattr(faker, protocol)()
         if isinstance(field, EmailField): return lambda x: faker.email()
-        if isinstance(field, CommaSeparatedIntegerField):
+        if isinstance(field, CommaSeparatedIntegerField) or \
+                (isinstance(field, CharField) and (validate_comma_separated_integer_list in field.validators)):
             return lambda x: provider.comma_sep_ints()
 
         if isinstance(field, BinaryField): return lambda x: provider.binary()

--- a/django_seed/management/commands/seed.py
+++ b/django_seed/management/commands/seed.py
@@ -22,8 +22,7 @@ class Command(AppCommand):
         super(Command, self).add_arguments(parser)
 
         parser.add_argument('--number', nargs='?', type=int, default=10, const=10,
-                    help='number of each model to seed')
-
+                            help='number of each model to seed')
 
     def handle_app_config(self, app_config, **options):
         if app_config.models_module is None:
@@ -37,6 +36,9 @@ class Command(AppCommand):
         seeder = Seed.seeder()
 
         for model in self.sorted_models(app_config):
+            if model in options.get('exclude_models', []):
+                continue
+
             seeder.add_entity(model, number)
             print('Seeding %i %ss' % (number, model.__name__))
 
@@ -60,4 +62,3 @@ class Command(AppCommand):
             return toposort_flatten(dependencies)
         except ValueError as ex:
             raise SeederCommandError(str(ex))
-

--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.core.management import call_command
+from django.core.validators import validate_comma_separated_integer_list
 from django.db import models
 from django.utils import timezone
 
@@ -66,8 +67,8 @@ class Player(models.Model):
     score = models.BigIntegerField()
     last_login_at = models.DateTimeField()
     game = models.ForeignKey(Game)
-    # ip = models.IPAddressField()
-    achievements = models.CommaSeparatedIntegerField(max_length=1000)
+    ip = models.GenericIPAddressField()
+    achievements = models.CharField(validators=[validate_comma_separated_integer_list], max_length=1000)
     friends = models.PositiveIntegerField()
     balance = models.FloatField()
 

--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -4,9 +4,8 @@ from contextlib import contextmanager
 from datetime import datetime
 
 from django.conf import settings
-from django.contrib.gis.geos import Point
-from django.contrib.gis.db import models
 from django.core.management import call_command
+from django.db import models
 from django.utils import timezone
 
 from django_seed.guessers import NameGuesser, FieldTypeGuesser
@@ -16,6 +15,7 @@ from django_seed import Seed
 
 from faker import Faker
 from alphabet_detector import AlphabetDetector
+from jsonfield import JSONField
 
 try:
     from django.utils.unittest import TestCase
@@ -90,7 +90,7 @@ class Action(models.Model):
 
 
 class NotCoveredFields(models.Model):
-    geo = models.PointField(null=True)
+    json = JSONField()
 
 
 class NameGuesserTestCase(TestCase):
@@ -178,11 +178,11 @@ class SeederTestCase(TestCase):
         faker = fake
         seeder = Seeder(faker)
         seeder.add_entity(NotCoveredFields, 10, {
-            'geo': lambda x: Point(float(seeder.faker.latitude()), float(seeder.faker.latitude())),
+            'json': lambda x: {seeder.faker.domain_name(): {'description': seeder.faker.text()}},
         })
         inserted_pks = seeder.execute()
         self.assertTrue(len(inserted_pks[NotCoveredFields]) == 10)
-        self.assertTrue(all([field.geo for field in NotCoveredFields.objects.all()]))
+        self.assertTrue(all([field.json for field in NotCoveredFields.objects.all()]))
 
     def test_locale(self):
         ad = AlphabetDetector()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ coverage
 django-nose
 nose
 alphabet-detector
+jsonfield

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ Faker
 coverage
 django-nose
 nose
+alphabet-detector

--- a/runtests.py
+++ b/runtests.py
@@ -12,7 +12,7 @@ def configure():
     settings.configure(
         DATABASES={
             'default': {
-                'ENGINE': 'django.contrib.gis.db.backends.spatialite',
+                'ENGINE': 'django.db.backends.sqlite3',
                 'NAME': ':memory:',
             }
         },
@@ -20,8 +20,8 @@ def configure():
             'django_seed',
             'django_nose',
         ),
-        TEST_RUNNER='django_nose.NoseTestSuiteRunner',
-        NOSE_ARGS=[
+        TEST_RUNNER = 'django_nose.NoseTestSuiteRunner',
+        NOSE_ARGS = [
             '--with-coverage',
             '--cover-package=django_seed',
         ],

--- a/runtests.py
+++ b/runtests.py
@@ -12,7 +12,7 @@ def configure():
     settings.configure(
         DATABASES={
             'default': {
-                'ENGINE': 'django.db.backends.sqlite3',
+                'ENGINE': 'django.contrib.gis.db.backends.spatialite',
                 'NAME': ':memory:',
             }
         },
@@ -20,8 +20,8 @@ def configure():
             'django_seed',
             'django_nose',
         ),
-        TEST_RUNNER = 'django_nose.NoseTestSuiteRunner',
-        NOSE_ARGS = [
+        TEST_RUNNER='django_nose.NoseTestSuiteRunner',
+        NOSE_ARGS=[
             '--with-coverage',
             '--cover-package=django_seed',
         ],
@@ -30,7 +30,7 @@ def configure():
     )
 
 
-if not settings.configured: 
+if not settings.configured:
     configure()
 
 


### PR DESCRIPTION
1. Fixed bug, which did not localize Faker's data; + test;
2. In order to avoid 'AttributeError(field)' when in a Model there are fields
which are not covered by django-seed, user can handle such fields in a custom
function manually.

Example for PointField and JSONField:

from django.contrib.gis.geos import Point

seeder.add_entity(Player, 10, {
    'geo' : lambda x: Point(float(seeder.faker.latitude()), float(seeder.faker.latitude())),
    'site': lambda x: {seeder.faker.domain_name(): {'description': seeder.faker.text()}},
})
seeder.execute()

+ test (Because 'JSONField' is not covered by Django-seed, in order to create a test for this case and do not break existsing tests, it was necessary to modify a bit a mananement file);

3. Test fixes (removed "IPAddressField" and deprecated "CommaSeparatedIntegerField);
4. Readme updates.

-----------------------------------------------

Also there are small clean ups.

P.S. Sorry that so many commits - this is my 1st work with PR\tests\Travis.

Travis shows an error about 'default' codename\locale. I checked Faker code and do not have any ideas what 'codename' and 'default' locale mean. Is there anyone who can explain the purpose of `codename` and `default` locale? Then I can fix it.