### PR TITLE
Refactoring tests and default field value.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ var/
 
 env/
 .idea
+.vscode

--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -1,7 +1,6 @@
 from django.db.models import *
 from django.conf import settings
 from django.utils import timezone
-from pprint import pprint
 
 import random
 import re

--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -1,6 +1,7 @@
 from django.db.models import *
 from django.conf import settings
 from django.utils import timezone
+from pprint import pprint
 
 import random
 import re
@@ -65,7 +66,6 @@ class FieldTypeGuesser(object):
         """
         faker = self.faker
         provider = self.provider
-
 
         if isinstance(field, DurationField): return lambda x: provider.duration()
         if isinstance(field, UUIDField): return lambda x: provider.uuid()

--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -38,7 +38,13 @@ class ModelSeeder(object):
         field_type_guesser = FieldTypeGuesser(faker)
 
         for field in self.model._meta.fields:
+
             field_name = field.name
+
+            if field.get_default(): 
+                formatters[field_name] = field.get_default()
+                continue
+            
             if isinstance(field, (ForeignKey, ManyToManyField, OneToOneField)):
                 formatters[field_name] = self.build_relation(field, field.related_model)
                 continue

--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -40,7 +40,7 @@ class ModelSeeder(object):
         for field in self.model._meta.fields:
             field_name = field.name
             if isinstance(field, (ForeignKey, ManyToManyField, OneToOneField)):
-                formatters[field_name] = self.build_relation(field, field.rel.to)
+                formatters[field_name] = self.build_relation(field, field.related_model)
                 continue
 
             if isinstance(field, AutoField):

--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -86,6 +86,13 @@ class Action(models.Model):
     actor = models.ForeignKey(to=Player,on_delete=models.CASCADE,related_name='actions', null=False)
     target = models.ForeignKey(to=Player,on_delete=models.CASCADE, related_name='enemy_actions+', null=True)
 
+class Product(models.Model):
+
+    name = models.CharField(max_length=100)
+    short_description = models.CharField(max_length=100, default='default short description')
+    description = models.TextField(default='default long description')
+    enabled = models.BooleanField(default=True)
+
 
 class NameGuesserTestCase(TestCase):
 
@@ -258,3 +265,32 @@ class SeedCommandTestCase(TestCase):
         except Exception as e:
             self.assertTrue(isinstance(e, SeederCommandError))
         pass
+
+class DefaultValueTestCase(TestCase):
+
+    def test_default_value_guessed_by_field_type(self):
+        faker = fake
+        seeder = Seeder(faker)
+
+        seeder.add_entity(Product, 1, {'name':'Awesome Product'})
+        _id = seeder.execute()
+
+        self.assertIsNotNone(_id)
+
+        product = Product.objects.get(id=_id[Product][0])
+
+        self.assertEquals(product.short_description, 'default short description')
+        self.assertTrue(product.enabled)
+
+    def test_default_value_guessed_by_field_name(self):
+        faker = fake
+        seeder = Seeder(faker)
+
+        seeder.add_entity(Product, 1, {'name':'Great Product'})
+        _id = seeder.execute()
+
+        self.assertIsNotNone(_id)
+
+        product = Product.objects.get(id=_id[Product][0])
+
+        self.assertEquals(product.description, 'default long description')

--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -63,7 +63,7 @@ class Player(models.Model):
     avatar = models.FilePathField()
     score = models.BigIntegerField()
     last_login_at = models.DateTimeField()
-    game = models.ForeignKey(Game)
+    game = models.ForeignKey(to=Game, on_delete=models.CASCADE)
     ip = models.IPAddressField()
     achievements = models.CommaSeparatedIntegerField(max_length=1000)
     friends = models.PositiveIntegerField()
@@ -83,8 +83,8 @@ class Action(models.Model):
     executed_at = models.DateTimeField()
     duration = models.DurationField()
     uuid = models.UUIDField()
-    actor = models.ForeignKey(Player,related_name='actions', null=False)
-    target = models.ForeignKey(Player, related_name='enemy_actions+', null=True)
+    actor = models.ForeignKey(to=Player,on_delete=models.CASCADE,related_name='actions', null=False)
+    target = models.ForeignKey(to=Player,on_delete=models.CASCADE, related_name='enemy_actions+', null=True)
 
 
 class NameGuesserTestCase(TestCase):


### PR DESCRIPTION
This solve [Issue #31](https://github.com/Brobin/django-seed/issues/31) and my own.

When a field have an default value, prevent `faker` generate data, but rather assign it with his default value, defined in model.

