### PR TITLE
Max length restrictions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
-    omit = 
-        *__init__.py*
+omit =
+    *__init__.py*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+    omit = 
+        *__init__.py*

--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -25,7 +25,7 @@ class NameGuesser(object):
 
     def guess_format(self, name):
         """
-        Returns a faker method baed on the field's name
+        Returns a faker method based on the field's name
         :param name:
         """
         name = name.lower()

--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -6,7 +6,6 @@ from django.db.models.fields import AutoField
 from django_seed.exceptions import SeederException
 from django_seed.guessers import NameGuesser, FieldTypeGuesser
 
-
 class ModelSeeder(object):
     def __init__(self, model):
         """
@@ -87,10 +86,19 @@ class ModelSeeder(object):
         manager = self.model.objects.db_manager(using=using)
         turn_off_auto_add(manager.model)
 
-        obj = manager.create(**{
+        faker_data = {
             field: format_field(field_format, inserted_entities)
             for field, field_format in self.field_formatters.items()
-        })
+        }
+
+        # max length restriction check
+        for data_field in faker_data:
+            field = self.model._meta.get_field(data_field)
+
+            if field.max_length:
+                faker_data[data_field] = faker_data[data_field][:field.max_length]
+
+        obj = manager.create(**faker_data)
 
         return obj.pk
 
@@ -124,7 +132,7 @@ class Seeder(object):
         model.field_formatters = model.guess_field_formatters(self.faker)
         if customFieldFormatters:
             model.field_formatters.update(customFieldFormatters)
-
+        
         klass = model.model
         self.entities[klass] = model
         self.quantities[klass] = number

--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -95,7 +95,7 @@ class ModelSeeder(object):
         for data_field in faker_data:
             field = self.model._meta.get_field(data_field)
 
-            if field.max_length:
+            if field.max_length and isinstance(faker_data[data_field], str):
                 faker_data[data_field] = faker_data[data_field][:field.max_length]
 
         obj = manager.create(**faker_data)

--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -23,6 +23,9 @@ except:
 
 fake = Faker()
 
+DEF_LD = "default long description"
+DEF_SD = "default short description"
+
 @contextmanager
 def django_setting(name, value):
     """
@@ -87,8 +90,8 @@ class Action(models.Model):
 
 class Product(models.Model):
     name = models.CharField(max_length=100)
-    short_description = models.CharField(max_length=100, default='default short description')
-    description = models.TextField(default='default long description')
+    short_description = models.CharField(max_length=100, default=DEF_SD)
+    description = models.TextField(default=DEF_LD)
     enabled = models.BooleanField(default=True)
 
 class Customer(models.Model):
@@ -284,7 +287,7 @@ class DefaultValueTestCase(TestCase):
 
         product = Product.objects.get(id=_id[Product][0])
 
-        self.assertEquals(product.short_description, 'default short description')
+        self.assertEquals(product.short_description, DEF_SD)
         self.assertTrue(product.enabled)
 
     def test_default_value_guessed_by_field_name(self):
@@ -298,7 +301,7 @@ class DefaultValueTestCase(TestCase):
 
         product = Product.objects.get(id=_id[Product][0])
 
-        self.assertEquals(product.description, 'default long description')
+        self.assertEquals(product.description, DEF_LD)
 
 class LengthRulesTestCase(TestCase):
 
@@ -340,3 +343,20 @@ class LengthRulesTestCase(TestCase):
         self.assertTrue(len(customer.comments) <= comments_max_len,
             "comments with length {}, does not respect max length restriction of {}"
             .format(len(customer.comments), comments_max_len))
+
+
+
+
+    def test_default_with_max_length(self):
+        faker = fake
+        seeder = Seeder(faker)
+
+        seeder.add_entity(Product, 1)
+
+        _id = seeder.execute()
+
+        product = Product.objects.get(id=_id[Product][0])
+
+        self.assertTrue(len(DEF_LD) == len(product.description))
+
+

--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -69,7 +69,6 @@ class Player(models.Model):
     friends = models.PositiveIntegerField()
     balance = models.FloatField()
 
-
 class Action(models.Model):
     ACTION_FIRE ='fire'
     ACTION_MOVE ='move'
@@ -87,11 +86,17 @@ class Action(models.Model):
     target = models.ForeignKey(to=Player,on_delete=models.CASCADE, related_name='enemy_actions+', null=True)
 
 class Product(models.Model):
-
     name = models.CharField(max_length=100)
     short_description = models.CharField(max_length=100, default='default short description')
     description = models.TextField(default='default long description')
     enabled = models.BooleanField(default=True)
+
+class Customer(models.Model):
+    name = models.CharField(max_length=255)
+    country = models.CharField(max_length=30)
+    address = models.CharField(max_length=50)
+    created_at = models.DateTimeField(auto_now=False, auto_now_add=True)
+    comments = models.TextField(max_length=500)
 
 
 class NameGuesserTestCase(TestCase):
@@ -294,3 +299,44 @@ class DefaultValueTestCase(TestCase):
         product = Product.objects.get(id=_id[Product][0])
 
         self.assertEquals(product.description, 'default long description')
+
+class LengthRulesTestCase(TestCase):
+
+    def test_max_length(self):
+        faker = fake
+        seeder = Seeder(faker)
+
+        name_max_len = Customer._meta.get_field('name').max_length
+        country_max_len = Customer._meta.get_field('country').max_length
+        address_max_len = Customer._meta.get_field('address').max_length
+        comments_max_len = Customer._meta.get_field('comments').max_length
+
+        rand = random.randint(1, 10)
+
+        data = {
+            'name': 'x' * (name_max_len + rand),
+            'country': 'p' * (country_max_len + rand),
+            'address': 't' * (address_max_len + rand),
+            'comments': 'o' * (comments_max_len + rand),
+        }
+
+        seeder.add_entity(Customer, 1, data)
+        _id = seeder.execute()
+
+        customer = Customer.objects.get(id=_id[Customer][0])
+
+        self.assertTrue(len(customer.name) <= name_max_len, 
+            "name with length {}, does not respect max length restriction of {}"
+            .format(len(customer.name), name_max_len))
+
+        self.assertTrue(len(customer.country) <= country_max_len,
+            "country with length {}, does not respect max length restriction of {}"
+            .format(len(customer.name), country_max_len))
+
+        self.assertTrue(len(customer.address) <= address_max_len,
+            "address with length {}, does not respect max length restriction of {}"
+            .format(len(customer.name), address_max_len))
+
+        self.assertTrue(len(customer.comments) <= comments_max_len,
+            "comments with length {}, does not respect max length restriction of {}"
+            .format(len(customer.comments), comments_max_len))

--- a/runtests.py
+++ b/runtests.py
@@ -44,5 +44,3 @@ def runtests():
 
 if __name__ == '__main__':
     runtests()
-
-


### PR DESCRIPTION

This PR fix [ Issue #40 ](https://github.com/Brobin/django-seed/issues/40) and some troubles i got.

When a field have `max_length` attribute, the seeder must obey his configured size, by slicing the string.

Also, I removed the `__init__.py` files from your code coverage, whose can affect your results.

Hope this can be useful.
Cheers.