### PR TITLE
Fix user-specified locale not being used

### DIFF
--- a/django_seed/__init__.py
+++ b/django_seed/__init__.py
@@ -31,7 +31,7 @@ class Seed(object):
         code = codename or cls.codename(locale)
         if code not in cls.fakers:
             from faker import Faker
-            cls.fakers[code] = Faker(locale)
+            cls.fakers[code] = Faker(code)
             cls.fakers[code].seed(random.randint(1, 10000))
         return cls.fakers[code]
 


### PR DESCRIPTION
Addresses issue where faker uses default locale even when a locale is explicitly specified:
```
In [1]: from django_seed import Seed                                                         

In [2]: s = Seed.seeder(locale='sv_SE')                                                      

In [3]: s.faker.city()                                                                       
Out[3]: 'North Kellyton'
```
After fix:
```
In [3]: s.faker.city()                                                                       
Out[3]: 'Västerås'
```
