### PR TITLE
Ignore DST on random date time objects since they might be ambiguous …

### DIFF
--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -15,7 +15,9 @@ def _timezone_format(value):
     :param value: The datetime value
     :return: A locale aware datetime
     """
-    return timezone.make_aware(value, timezone.get_current_timezone()) if getattr(settings, 'USE_TZ', False) else value
+    if getattr(settings, 'USE_TZ', False):
+        return timezone.make_aware(value, timezone.get_current_timezone(), is_dst=False)
+    return value
 
 
 class NameGuesser(object):


### PR DESCRIPTION
`timezone.make_aware` might call timezone.localise on the date time which might result in a non-existent or ambiguous date time, because of Daylight saving time. 

Example:
```
$ timezone.make_aware(datetime.datetime(2008, 10, 26, 2, 26, 40), pytz.timezone('Europe/Amsterdam'))
pytz.exceptions.AmbiguousTimeError: 2008-10-26 02:26:40
```

Since we are using random date time objects anyway, we might as well ignore DST, which will fix the issue.