### PR TITLE
Include LICENSE and runtests.py in pypi archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include *.rst
+include LICENSE
+include runtests.py


### PR DESCRIPTION
With versions tagged on pypi we need to have license file and also a way how to execute tests there for others to use.