### PR TITLE
Add test case for _default_hint guesser fallback

### DIFF
--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -172,6 +172,7 @@ class FieldTypeGuesserTestCase(TestCase):
             value = generator(datetime.now())
             self.assertFalse(timezone.is_aware(value))
 
+    @skipIf(django_version[0] < 2, "JSONField does not work with Django 1.11")
     def test_guess_not_in_format(self):
         from django.contrib.postgres.fields.jsonb import JSONField
         # postgres native JSONField has the _default_hint

--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -172,10 +172,11 @@ class FieldTypeGuesserTestCase(TestCase):
             value = generator(datetime.now())
             self.assertFalse(timezone.is_aware(value))
 
-    # TODO: Find model field with _default_hint to use in test
-    # def test_guess_not_in_format(self):
-    #     generator = self.instance.guess_format(JSONField())
-    #     self.assertEquals(generator(), '{}')
+    def test_guess_not_in_format(self):
+        from django.contrib.postgres.fields.jsonb import JSONField
+        # postgres native JSONField has the _default_hint
+        generator = self.instance.guess_format(JSONField())
+        self.assertEquals(generator({}), '{}')
 
 class SeederTestCase(TestCase):
 
@@ -411,7 +412,7 @@ class LengthRulesTestCase(TestCase):
 
         customer = Customer.objects.get(id=_id[Customer][0])
 
-        self.assertTrue(len(customer.name) <= name_max_len, 
+        self.assertTrue(len(customer.name) <= name_max_len,
             "name with length {}, does not respect max length restriction of {}"
             .format(len(customer.name), name_max_len))
 
@@ -467,7 +468,7 @@ class RelationshipTestCase(TestCase):
     def test_many_to_one(self):
         faker = fake
         seeder = Seeder(faker)
-        
+
         seeder.add_entity(Pen, 1)
         seeder.add_entity(Reporter, 1)
         seeder.add_entity(Article, 1)
@@ -490,7 +491,7 @@ class RelationshipTestCase(TestCase):
     def test_many_to_many(self):
         faker = fake
         seeder = Seeder(faker)
-        
+
         seeder.add_entity(Pen, 1)
         seeder.add_entity(Reporter, 1)
         seeder.add_entity(Article, 1)
@@ -514,7 +515,7 @@ class RelationshipTestCase(TestCase):
     #     seeder.add_entity(Article, 1)
 
     #     seeder.execute()
-        
+
     #     seeder.add_entity(Newspaper, 1)
 
     #     seeder.execute()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ django-nose
 nose
 alphabet-detector
 jsonfield
+psycopg2-binary


### PR DESCRIPTION
The postgres contrib JSONField (used for jsonb support in Django < 3.1) has a `_default_hint` field.