### PR TITLE
Fix postgres arrayfield

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,19 @@ jobs:
           - python-version: 3.8
             django-version: 1.11
 
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -35,3 +48,4 @@ jobs:
       - name: Run tests
         run: |
           python runtests.py
+          python runtests.py --database=postgres

--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -2,6 +2,7 @@ from django.db.models import *
 from django.conf import settings
 from django.core.validators import validate_comma_separated_integer_list
 from django.utils import timezone
+from django.contrib.postgres.fields import ArrayField
 
 import random
 import re
@@ -108,6 +109,7 @@ class FieldTypeGuesser(object):
             return lambda x: _timezone_format(faker.date_time())
         if isinstance(field, DateField): return lambda x: faker.date()
         if isinstance(field, TimeField): return lambda x: faker.time()
+        if isinstance(field, ArrayField): return lambda x: [faker.text()]
 
         # TODO: This should be fine, but I can't find any models that I can use
         # in a simple test case.

--- a/django_seed/tests.py
+++ b/django_seed/tests.py
@@ -19,9 +19,6 @@ from faker import Faker
 from alphabet_detector import AlphabetDetector
 from jsonfield import JSONField
 
-from django.core import management
-from django.core.management.commands import loaddata
-
 try:
     from django.utils.unittest import TestCase
 except:
@@ -362,6 +359,14 @@ class SeedCommandTestCase(TestCase):
             self.assertTrue(isinstance(e, SeederCommandError))
         pass
 
+    def test_seed_command_forced_field(self):
+        call_command('seed', 'django_seed', '--seeder', 'Customer.name', 'BobbyLongName', '--number=12')
+
+        customers = Customer.objects.all()
+        
+        self.assertTrue(customers[0].name == 'BobbyLongName')
+        self.assertTrue(len(customers) == 12)
+
 class DefaultValueTestCase(TestCase):
 
     def test_default_value_guessed_by_field_type(self):
@@ -526,12 +531,3 @@ class RelationshipTestCase(TestCase):
     #     self.assertNotEqual(Reporter.objects.get(id=1), None)
     #     self.assertNotEqual(Article.objects.get(id=1), None)
     #     self.assertEqual(len(Reporter.objects.get(id=1).newspaper_set.all()), 1)
-    
-class CLITestCase(TestCase):
-    def test_default_with_max_length(self):
-        management.call_command('seed', 'django_seed', '--seeder', 'Customer.name', 'BobbyLongName', '--number=12')
-
-        customers = Customer.objects.all()
-        
-        self.assertTrue(customers[0].name == 'BobbyLongName')
-        self.assertTrue(len(customers) == 12)

--- a/runtests.py
+++ b/runtests.py
@@ -3,19 +3,16 @@ import sys
 import django
 from django.conf import settings
 from django.test.utils import get_runner
+import sys
+from collections import defaultdict
 
 
-def configure():
+def configure(databases):
     from faker import Faker
     fake = Faker()
 
     settings.configure(
-        DATABASES={
-            'default': {
-                'ENGINE': 'django.db.backends.sqlite3',
-                'NAME': ':memory:',
-            }
-        },
+        DATABASES=databases,
         INSTALLED_APPS=(
             'django_seed',
             'django_nose',
@@ -31,7 +28,38 @@ def configure():
 
 
 if not settings.configured:
-    configure()
+    argv = sys.argv[1:]
+
+    args=defaultdict(list)
+    for k, v in ((k.lstrip('-'), v) for k,v in (a.split('=') for a in sys.argv[1:])):
+        args[k].append(v)
+
+    # Remove all args that are already 
+    sys.argv = list(filter(lambda arg: any(arg_name.startswith(arg) for arg_name in [
+        '--database'
+    ]), sys.argv))
+
+    databases = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': ':memory:',
+        }
+    }
+
+    # Used for tests in Github Actions
+    # Refer to .github/workflows/test.yml to see the Postgres service that is
+    # being hosted
+    if 'postgres' in args['database']:
+        databases['default'] = {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'dbtest', 
+            'USER': 'postgres', 
+            'PASSWORD': 'postgres',
+            'HOST': 'localhost', 
+            'PORT': '5432',
+        }
+
+    configure(databases)
 
 
 def runtests():


### PR DESCRIPTION
This closes #83. Although this fixes the problem, there isn't an easy way to add a test. Since it needs to be tested on a Postgres database, it can't be done in memory during dev. I think maybe spawning a Postgres DB to run alongside the actions might be a good idea, but then people testing in dev would have to have it disabled.