### PR TITLE
Feature enhancement: option to truncate model tables before seeding

### DIFF
--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -213,16 +213,18 @@ class Seeder(object):
         }
         self.orders.append(order)
 
-    def execute(self, using=None, inserted_entities={}):
+    def execute(self, using=None, inserted_entities=None):
         """
         Populate the database using all the Entity classes previously added.
         :param using A Django database connection name
         :rtype: A list of the inserted PKs
         """
+        if inserted_entities is None:
+            inserted_entities = {}
+
         if not using:
             using = self.get_connection()
 
-        inserted_entities = {}
         while len(self.orders):
             order = self.orders.pop(0)
             number = order["quantity"]


### PR DESCRIPTION
Reference: #81 

* Implement feature to truncate model tables before seeding
* Address shadowed/mutable kwarg in execute method

Sorry I had to submit this twice; I didn't notice the change from the master branch to the main branch, which brought in extra commits at first.

If accepted, please tag the merge with the label **hacktoberfest-accepted**.