### PR TITLE
bugfix: Remove is_dst from _timezone_format from guessers.py. #119

### DIFF
--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -24,7 +24,7 @@ def _timezone_format(value):
     :return: A locale aware datetime
     """
     if getattr(settings, 'USE_TZ', False):
-        return timezone.make_aware(value, timezone.get_current_timezone(), is_dst=False)
+        return timezone.make_aware(value, timezone.get_current_timezone())
     return value
 
 


### PR DESCRIPTION
This PR resolve Issue https://github.com/Brobin/django-seed/issues/119