### PR TITLE
Change the data structure of the `orders` attribute in the `Seeder` class to deque

### DIFF
--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -1,4 +1,5 @@
 import random, logging
+from collections import deque
 
 from django.db.models import ForeignKey, ManyToManyField, OneToOneField
 
@@ -183,7 +184,7 @@ class Seeder(object):
         :param faker: Generator
         """
         self.faker = faker
-        self.orders = []
+        self.orders = deque()
 
     def add_entity(self, model, number, customFieldFormatters=None):
         """
@@ -224,7 +225,7 @@ class Seeder(object):
 
         inserted_entities = {}
         while len(self.orders):
-            order = self.orders.pop(0)
+            order = self.orders.popleft()
             number = order["quantity"]
             klass = order["klass"]
             entity = order["entity"]


### PR DESCRIPTION
- Change the data structure of the `orders` attribute in the `Seeder` class to deque

I've made some changes to improve execution speed by using `popleft()` from deque instead of using `pop(0)` with the standard list type :)
