### PR TITLE
Use logging.warning instead of deprecated/removed logging.warn method

### DIFF
--- a/django_seed/guessers.py
+++ b/django_seed/guessers.py
@@ -24,7 +24,7 @@ def _timezone_format(value):
     :return: A locale aware datetime
     """
     if getattr(settings, 'USE_TZ', False):
-        return timezone.make_aware(value, timezone.get_current_timezone(), is_dst=False)
+        return timezone.make_aware(value, timezone.get_current_timezone())
     return value
 
 

--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -125,10 +125,10 @@ class ModelSeeder(object):
                 formatters[field_name] = formatter
                 continue
 
-        for field in self.model._meta.many_to_many:
-            self.many_relations[field.name] = self.build_many_relation(
-                field, field.related_model
-            )
+        # for field in self.model._meta.many_to_many:
+        #     self.many_relations[field.name] = self.build_many_relation(
+        #         field, field.related_model
+        #     )
 
         return formatters
 
@@ -248,12 +248,12 @@ class Seeder(object):
                     # continue testing on an IntegrityError
                     with transaction.atomic():
                         executed_entity = entity.execute(using, inserted_entities)
-                        
+
                     inserted_entities[klass].append(executed_entity)
                     completed_count += 1
                 except IntegrityError as err:
                     last_error = err
-                
+
                 # Exit if the right number of entities has been inserted
                 if completed_count == number:
                     break

--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -61,7 +61,7 @@ class ModelSeeder(object):
                 message = "Field {} cannot be null".format(field)
                 raise SeederException(message)
             else:
-                logging.warn(
+                logging.warning(
                     "Could not build many-to-many relationship for between {} and {}".format(
                         field,
                         related_model,


### PR DESCRIPTION
This change set replaces `logging.warn` with `logging.warning` in seeder.py.

AFAICT, the `warn` method was initialled deprecated in Python 3.3 and finally removed by Python 3.11. 

I _think_ setup.py may also need to be modified but let's discuss. In the meantime, I can verify that this branch works in a project which is testing Python 3.13rc0.