### PR TITLE
Use logging.warning instead of deprecated/removed logging.warn method

### DIFF
--- a/django_seed/seeder.py
+++ b/django_seed/seeder.py
@@ -61,7 +61,7 @@ class ModelSeeder(object):
                 message = "Field {} cannot be null".format(field)
                 raise SeederException(message)
             else:
-                logging.warn(
+                logging.warning(
                     "Could not build many-to-many relationship for between {} and {}".format(
                         field,
                         related_model,


### PR DESCRIPTION
This change set replaces logging.warn with logging.warning in seeder.py.

AFAICT, the warn method was initialled deprecated in Python 3.3 and finally removed by Python 3.11.

I think setup.py may also need to be modified but let's discuss. In the meantime, I can verify that this branch works in a project which is testing Python 3.13rc0.